### PR TITLE
Remove turbopack from dev script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ yarn-error.log*
 # build outputs
 /tools/preset-sync/index.js
 /toolkit/package/dist
+
+.env

--- a/package.json
+++ b/package.json
@@ -191,5 +191,6 @@
   "resolutions": {
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/tools/scripts/dev.sh
+++ b/tools/scripts/dev.sh
@@ -21,5 +21,5 @@ dotenv \
   -e .env.local \
   -e .env.development \
   -e .env \
-  -- bash -c './deploy/scripts/make_envs_script.sh && next dev --turbopack -p $NEXT_PUBLIC_APP_PORT' |
+  -- bash -c './deploy/scripts/make_envs_script.sh && next dev -p $NEXT_PUBLIC_APP_PORT' |
 pino-pretty


### PR DESCRIPTION
`yarn dev` local run script fails because a turbopack misconfiguration. This PR removes the `--turbopack` flag and rollback to webpack to solve the problem